### PR TITLE
Use 'where' instead of 'which' on Windows.

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/RustGDBLaunchWrapper.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/RustGDBLaunchWrapper.java
@@ -67,7 +67,7 @@ public class RustGDBLaunchWrapper extends GdbLaunch {
 	private String getGDBLocation() {
 		String[] command = new String[] { "/bin/bash", "-c", "which gdb" };
 		if (Platform.getOS().equals(Platform.OS_WIN32)) {
-			command = new String[] { "cmd", "/c", "which gdb" };
+			command = new String[] { "cmd", "/c", "where gdb" };
 		}
 		try {
 			Process process = Runtime.getRuntime().exec(command);


### PR DESCRIPTION
Which command doesn't exist on windows so better to rely on where
(should give full path to gdb executable if on syspath).
Should improve #64 on windows.