### PR TITLE
#79 - Prevent competion assist in comments

### DIFF
--- a/org.eclipse.corrosion.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.corrosion.tests/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Require-Bundle: org.eclipse.corrosion;bundle-version="0.1.0",
  org.eclipse.core.expressions,
  org.eclipse.search,
  org.eclipse.ui.console,
- org.eclipse.debug.ui;bundle-version="3.13.0"
+ org.eclipse.debug.ui;bundle-version="3.13.0",
+ org.eclipse.jface.text;bundle-version="3.13.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/AllTests.java
+++ b/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/AllTests.java
@@ -19,7 +19,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({ TestIDEIntegration.class, TestSyntaxHighlighting.class, TestLSPIntegration.class,
 	TestNewCargoProjectWizard.class, TestRunConfiguration.class, TestExportCargoProjectWizard.class,
-	TestPerspective.class, TestLSPExtensions.class })
+	TestPerspective.class, TestLSPExtensions.class, TestSnippetContentAssistProcessor.class })
 public class AllTests {
 
 }

--- a/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/TestSnippetContentAssistProcessor.java
+++ b/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/TestSnippetContentAssistProcessor.java
@@ -1,0 +1,97 @@
+/*********************************************************************
+ * Copyright (c) 2018 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Lucas Bullen   (Red Hat Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.corrosion.snippet.SnippetContentAssistProcessor;
+import org.eclipse.jface.text.ITextOperationTarget;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.lsp4e.operations.completion.LSCompletionProposal;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.Test;
+
+@SuppressWarnings("restriction")
+public class TestSnippetContentAssistProcessor extends AbstractCorrosionTest {
+
+	@Test
+	public void testCompletionsPresent() throws Exception {
+		validateCompletionProposals("println", new String[] { "println!(\"$1\", $0)" });
+	}
+
+	@Test
+	public void testCompletionsLimited() throws Exception {
+		validateCompletionProposals("noExpectedCompletion", null);
+	}
+
+	@Test
+	public void testSingleLineComment() throws Exception {
+		validateCompletionProposals("// println", null);
+		// With prefix
+		validateCompletionProposals("not a comment // println", null);
+		// With multiline
+		validateCompletionProposals("not a comment \n also not a comment // println", null);
+		// Comment on an above line
+		validateCompletionProposals("// a comment \n println", new String[] { "println!(\"$1\", $0)" });
+	}
+
+	@Test
+	public void testMultiLineComment() throws Exception {
+		validateCompletionProposals("/* println", null);
+		// With prefix
+		validateCompletionProposals("not a comment /* println", null);
+		// With multiline
+		validateCompletionProposals("not a comment \n not a comment /* println", null);
+		// With mulitple opens
+		validateCompletionProposals("not a comment \n not a comment /* in /* /* println", null);
+		// Previous closure
+		validateCompletionProposals("/* in a comment */ not a comment /* println", null);
+		// Previous closue no open
+		validateCompletionProposals("/* in a comment */ println", new String[] { "println!(\"$1\", $0)" });
+		// Previous closue new line
+		validateCompletionProposals("/* in a comment */ \n  println", new String[] { "println!(\"$1\", $0)" });
+
+	}
+
+	private void validateCompletionProposals(String text, String[] expectedProposalTexts)
+			throws IOException, CoreException {
+		IProject project = getProject("basic");
+		IFile file = project.getFolder("src").getFile("main.rs");
+		IEditorPart editor = IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), file);
+		((ITextEditor) editor).getDocumentProvider().getDocument(editor.getEditorInput()).set(text);
+
+		ICompletionProposal[] proposals = (new SnippetContentAssistProcessor()).computeCompletionProposals(
+				(ITextViewer) editor.getAdapter(ITextOperationTarget.class), text.length() - 1);
+		if (expectedProposalTexts == null) {
+			assertTrue(proposals == null || proposals.length == 0);
+			return;
+		}
+		assertNotNull(proposals);
+		for (int i = 0; i < proposals.length; i++) {
+			assertEquals(((LSCompletionProposal) proposals[i]).getItem().getTextEdit().getNewText(),
+					expectedProposalTexts[i]);
+		}
+	}
+
+}

--- a/org.eclipse.corrosion/META-INF/MANIFEST.MF
+++ b/org.eclipse.corrosion/META-INF/MANIFEST.MF
@@ -40,5 +40,6 @@ Export-Package: org.eclipse.corrosion;x-friends:="org.eclipse.corrosion.tests",
  org.eclipse.corrosion.edit;x-friends:="org.eclipse.corrosion.tests",
  org.eclipse.corrosion.extensions;x-friends:="org.eclipse.corrosion.tests",
  org.eclipse.corrosion.run;x-friends:="org.eclipse.corrosion.tests",
+ org.eclipse.corrosion.snippet;x-friends:="org.eclipse.corrosion.tests",
  org.eclipse.corrosion.wizards.export;x-friends:="org.eclipse.corrosion.tests",
  org.eclipse.corrosion.wizards.newCargo;x-friends:="org.eclipse.corrosion.tests"


### PR DESCRIPTION
 - Check to see if the cursor is in a Rust comment or not before
returning snippet completions

Signed-off-by: Lucas Bullen <lbullen@redhat.com>