### PR TITLE
Temporary fix for raw strings

### DIFF
--- a/org.eclipse.corrosion/grammar/Rust.tmLanguage
+++ b/org.eclipse.corrosion/grammar/Rust.tmLanguage
@@ -297,9 +297,9 @@
 		<key>rust_raw_string</key>
 		<dict>
 			<key>begin</key>
-			<string>r"</string>
+			<string>r(#*)"</string>
 			<key>end</key>
-			<string>"</string>
+			<string>"(\1)</string>
 			<key>name</key>
 			<string>string.quoted.double.raw.source.rust</string>
 		</dict>


### PR DESCRIPTION
Before maybe switching to a new grammar, this commit fixes syntax
coloration of raw strings. There can be a flexible amount of '#'
delimiters at the start and end of a raw string. This allows arbitrary
characters in the string (except the end sequence of " and the same
amount of '#' characters as in the beginning). For more info see:
https://doc.rust-lang.org/reference/tokens.html#characters-and-strings

Signed-off-by: Max Bureck <max.bureck@fokus.fraunhofer.de>