### PR TITLE
Fixed absolute path calculation for workspace resources

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
@@ -57,7 +57,7 @@ public class RustDebugDelegate extends GdbLaunchDelegate implements ILaunchShort
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 		String workingDirectoryString = RustLaunchDelegateTools.performVariableSubstitution(
 				configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, "").trim()); //$NON-NLS-1$
-		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(new File(workingDirectoryString));
+		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(workingDirectoryString);
 		if (workingDirectoryString.isEmpty() || !workingDirectory.exists() || !workingDirectory.isDirectory()) {
 			workingDirectory = project.getLocation().toFile();
 		}
@@ -150,13 +150,13 @@ public class RustDebugDelegate extends GdbLaunchDelegate implements ILaunchShort
 		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
 		String workingDirectoryString = RustLaunchDelegateTools.performVariableSubstitution(
 				configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, "").trim()); //$NON-NLS-1$
-		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(new File(workingDirectoryString));
+		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(workingDirectoryString);
 		if (workingDirectoryString.isEmpty() || !workingDirectory.exists() || !workingDirectory.isDirectory()) {
 			workingDirectory = project.getLocation().toFile();
 		}
 		String executableString = RustLaunchDelegateTools.performVariableSubstitution(
 				configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, "").trim()); //$NON-NLS-1$
-		File executable = RustLaunchDelegateTools.convertToAbsolutePath(new File(executableString));
+		File executable = RustLaunchDelegateTools.convertToAbsolutePath(executableString);
 
 		ILaunchConfigurationWorkingCopy wc = configuration.copy(configuration.getName() + "[Variables Parsed]") //$NON-NLS-1$
 				.getWorkingCopy();

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
@@ -83,10 +83,19 @@ public class RustLaunchDelegateTools {
 		return input.getAdapter(IResource.class);
 	}
 
-	public static File convertToAbsolutePath(File file) {
+	/**
+	 * Converts the given relative path to a workspace resource and converts it to a
+	 * {@code File} with the absolute path on the file system.
+	 *
+	 * @param path to a workspace resource
+	 * @return File object of the given {@code path}, with an absolute path on the
+	 *         file system
+	 */
+	public static File convertToAbsolutePath(String path) {
+		final File file = new File(path);
 		if (file.isAbsolute())
 			return file;
-		return ResourcesPlugin.getWorkspace().getRoot().getLocation().append(file.getPath()).toFile();
+		return ResourcesPlugin.getWorkspace().getRoot().findMember(file.getPath()).getRawLocation().toFile();
 	}
 
 	/**

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/run/CargoRunDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/run/CargoRunDelegate.java
@@ -69,7 +69,7 @@ public class CargoRunDelegate extends LaunchConfigurationDelegate implements ILa
 		String arguments = configuration.getAttribute(RustLaunchDelegateTools.ARGUMENTS_ATTRIBUTE, "").trim(); //$NON-NLS-1$
 		String workingDirectoryString = RustLaunchDelegateTools.performVariableSubstitution(
 				configuration.getAttribute(RustLaunchDelegateTools.WORKING_DIRECTORY_ATTRIBUTE, "").trim()); //$NON-NLS-1$
-		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(new File(workingDirectoryString));
+		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(workingDirectoryString);
 		if (workingDirectoryString.isEmpty() || !workingDirectory.exists() || !workingDirectory.isDirectory()) {
 			workingDirectory = project.getLocation().toFile();
 		}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/test/CargoTestDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/test/CargoTestDelegate.java
@@ -62,7 +62,7 @@ public class CargoTestDelegate extends LaunchConfigurationDelegate implements IL
 		String arguments = configuration.getAttribute(RustLaunchDelegateTools.ARGUMENTS_ATTRIBUTE, "").trim(); //$NON-NLS-1$
 		String workingDirectoryString = RustLaunchDelegateTools.performVariableSubstitution(
 				configuration.getAttribute(RustLaunchDelegateTools.WORKING_DIRECTORY_ATTRIBUTE, "").trim()); //$NON-NLS-1$
-		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(new File(workingDirectoryString));
+		File workingDirectory = RustLaunchDelegateTools.convertToAbsolutePath(workingDirectoryString);
 		if (workingDirectoryString.isEmpty() || !workingDirectory.exists() || !workingDirectory.isDirectory()) {
 			workingDirectory = null;
 		}


### PR DESCRIPTION
* Previously it was assumed that projects are physically stored below
  the workspace directory. When projects are located e.g. in a git
  repository and imported into the workspace this assumption does not
  hold. This was fixed with a proper lookup.

* Changed API of the convertToAbsolutePath method to take a string
  instead of a file, since all callers had to create a file from a
  string anyway.