### PR TITLE
Tiny improvement over PR #148

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
@@ -95,7 +95,7 @@ public class RustLaunchDelegateTools {
 		final File file = new File(path);
 		if (file.isAbsolute())
 			return file;
-		return ResourcesPlugin.getWorkspace().getRoot().findMember(file.getPath()).getRawLocation().toFile();
+		return ResourcesPlugin.getWorkspace().getRoot().findMember(path).getRawLocation().toFile();
 	}
 
 	/**


### PR DESCRIPTION
Sorry, this should have been part of my last pull request.
convertToAbsolutePath is now taking path directly in relative path case
instead of converting file back to a relative path string.

Signed-off-by: Max Bureck <max.bureck@fokus.fraunhofer.de>