### PR TITLE
Smoother debug program default for Windows OS

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/DebugUtil.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/DebugUtil.java
@@ -1,0 +1,43 @@
+/*********************************************************************
+ * Copyright (c) 2018 Fraunhofer FOKUS and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Max Bureck (Fraunhofer FOKUS) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.debug;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * This class contains static helper methods and fields to be used for the
+ * Debuging functionality in Eclipse Corrosion
+ */
+class DebugUtil {
+
+	private static final boolean IS_WINDOWS = Platform.getOS().equals(Platform.OS_WIN32);
+
+	/**
+	 * Returns the default workspace path to the executable produced for the given
+	 * project. This location is a guess based on the default rust/cargo project
+	 * layout and the operating system running eclipse.
+	 *
+	 * @param project Rust project for which the executable workspace path is
+	 *                computed.
+	 * @return default workspace path to the executable created for the given Rust
+	 *         {@code project}.
+	 */
+	static String getDefaultExecutablePath(IProject project) {
+		if (project == null) {
+			return ""; //$NON-NLS-1$
+		}
+		return project.getName() + "/target/debug/" + project.getName() + (IS_WINDOWS ? ".exe" : ""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+
+}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.corrosion.debug;
 
+import static org.eclipse.corrosion.debug.DebugUtil.getDefaultExecutablePath;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -184,8 +186,7 @@ public class RustDebugDelegate extends GdbLaunchDelegate implements ILaunchShort
 			ILaunchConfigurationWorkingCopy wc = (ILaunchConfigurationWorkingCopy) launchConfiguration;
 			final IProject project = resource.getProject();
 			wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME, project.getName());
-			wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME,
-					project.getName() + "/target/debug/" + project.getName()); //$NON-NLS-1$
+			wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_PROGRAM_NAME, getDefaultExecutablePath(project)); // $NON-NLS-1$
 			wc.setAttribute(ICDTLaunchConfigurationConstants.ATTR_DEBUGGER_STOP_AT_MAIN, false);
 			wc.setAttribute(IGDBLaunchConfigurationConstants.ATTR_DEBUG_NAME, "rust-gdb"); //$NON-NLS-1$
 		}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugTab.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugTab.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.corrosion.debug;
 
+import static org.eclipse.corrosion.debug.DebugUtil.getDefaultExecutablePath;
+
 import org.eclipse.cdt.debug.core.ICDTLaunchConfigurationConstants;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -74,7 +76,7 @@ public class RustDebugTab extends AbstractLaunchConfigurationTab {
 		buildInput.createVariableSelection();
 
 		executableInput = new OptionalDefaultInputComponent(container, Messages.RustDebugTab_Executable, updateListener,
-				() -> getDefaultExecutablePath());
+				() -> getDefaultExecutablePath(project));
 		executableInput.createComponent();
 		executableInput.createResourceSelection(() -> project);
 
@@ -91,18 +93,11 @@ public class RustDebugTab extends AbstractLaunchConfigurationTab {
 			project = null;
 		}
 		if (executableInput.getSelection()) {
-			executableInput.setValue(getDefaultExecutablePath());
+			executableInput.setValue(getDefaultExecutablePath(project));
 		}
 		if (workingDirectoryInput.getSelection()) {
 			workingDirectoryInput.setValue(getDefaultWorkingDirectoryPath());
 		}
-	}
-
-	private String getDefaultExecutablePath() {
-		if (project == null) {
-			return ""; //$NON-NLS-1$
-		}
-		return project.getName() + "/target/debug/" + project.getName(); //$NON-NLS-1$
 	}
 
 	private String getDefaultWorkingDirectoryPath() {
@@ -139,7 +134,7 @@ public class RustDebugTab extends AbstractLaunchConfigurationTab {
 		} catch (CoreException ce) {
 			executableInput.setValue(""); //$NON-NLS-1$
 		}
-		executableInput.updateSelection(executableInput.getValue().equals(getDefaultExecutablePath()));
+		executableInput.updateSelection(executableInput.getValue().equals(getDefaultExecutablePath(project)));
 		try {
 			workingDirectoryInput
 					.setValue(configuration.getAttribute(ICDTLaunchConfigurationConstants.ATTR_WORKING_DIRECTORY, "")); //$NON-NLS-1$

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
@@ -85,7 +85,9 @@ public class RustLaunchDelegateTools {
 
 	/**
 	 * Converts the given relative path to a workspace resource and converts it to a
-	 * {@code File} with the absolute path on the file system.
+	 * {@code File} with the absolute path on the file system. If file does not
+	 * exist in the workspace, the returned file will be based on the given relative
+	 * path.
 	 *
 	 * @param path to a workspace resource
 	 * @return File object of the given {@code path}, with an absolute path on the
@@ -93,9 +95,14 @@ public class RustLaunchDelegateTools {
 	 */
 	public static File convertToAbsolutePath(String path) {
 		final File file = new File(path);
-		if (file.isAbsolute())
+		if (file.isAbsolute()) {
 			return file;
-		return ResourcesPlugin.getWorkspace().getRoot().findMember(path).getRawLocation().toFile();
+		}
+		final IResource filePath = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
+		if (filePath == null) {
+			return file;
+		}
+		return filePath.getRawLocation().toFile();
 	}
 
 	/**


### PR DESCRIPTION
Unfortunately this does not fix the Problem that rust does not ship a working version of the rust-gdb wrapper for Windows, but this is a more difficult issue and I am not convinced a workaround should be put into Corrosion.

* Computing the default executable path on Windows now returns a path
  with the ".exe" suffix. This heuristic approach falls short when a
  rust toolchain for a different platform is selected (for cross-
  compilation). In future the location could be determined by the
  currently selected rust toolchain.

* Added a null-check to prevent a NullPointerException on non-existent
  workspace resources. This exception would silently be swallowed
  without feedback to the user.

Signed-off-by: Max Bureck <max.bureck@fokus.fraunhofer.de>