### PR TITLE
Added logging of status when determining GDB version fails

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/CorrosionPlugin.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/CorrosionPlugin.java
@@ -62,7 +62,11 @@ public class CorrosionPlugin extends AbstractUIPlugin {
 	}
 
 	public static void logError(Throwable t) {
-		getDefault().getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, t.getMessage(), t));
+		logError(new Status(IStatus.ERROR, PLUGIN_ID, t.getMessage(), t));
+	}
+
+	public static void logError(IStatus s) {
+		getDefault().getLog().log(s);
 	}
 
 	public static void showError(String title, String message, Exception exception) {

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
@@ -31,6 +31,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.variables.IStringVariableManager;
 import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.corrosion.CorrosionPlugin;
@@ -105,6 +106,10 @@ public class RustDebugDelegate extends GdbLaunchDelegate implements ILaunchShort
 		try {
 			super.launch(configuration, mode, launch, monitor);
 		} catch (CoreException e) {
+			IStatus status = e.getStatus();
+			if (status != null) {
+				CorrosionPlugin.logError(status);
+			}
 			CorrosionPlugin.showError(Messages.RustDebugDelegate_unableToLaunch_title,
 					Messages.RustDebugDelegate_unableToLaunch_message, e);
 		}


### PR DESCRIPTION
When looking up the GDB version fails, the cause is now logged.
This can be used to gain insight what goes wrong on user's machines.
Currently it seems very much unclear what is happening here.

Signed-off-by: Max Bureck <max.bureck@fokus.fraunhofer.de>