### PR TITLE
Fix #167 - Syntax highlighting for all *.toml files

### DIFF
--- a/org.eclipse.corrosion/OSGI-INF/l10n/bundle.properties
+++ b/org.eclipse.corrosion/OSGI-INF/l10n/bundle.properties
@@ -3,6 +3,7 @@ Bundle-Vendor = Eclipse Corrosion
 Bundle-Name = Rust edition in Eclipse IDE
 content-type.name = Rust project file
 content-type.name.0 = Cargo manifest file
+toml.content-type.name = Toml file
 page.name = Rust
 page.name.0 = Text Editor
 category.name = Rust

--- a/org.eclipse.corrosion/plugin.xml
+++ b/org.eclipse.corrosion/plugin.xml
@@ -5,13 +5,20 @@
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.text"
+            file-extensions="toml"
+            id="org.eclipse.corrosion.toml"
+            name="%toml.content-type.name"
+            priority="normal">
+      </content-type>
+      <content-type
+            base-type="org.eclipse.core.runtime.text"
             file-extensions="rs"
             id="org.eclipse.corrosion.rust"
             name="%content-type.name"
             priority="normal">
       </content-type>
       <content-type
-            base-type="org.eclipse.core.runtime.text"
+            base-type="org.eclipse.corrosion.toml"
             file-names="Cargo.toml"
             id="org.eclipse.corrosion.manifest"
             name="%content-type.name.0"
@@ -25,7 +32,7 @@
         editorId="org.eclipse.ui.genericeditor.GenericEditor">
    		</editorContentTypeBinding>
      <editorContentTypeBinding
-        contentTypeId="org.eclipse.corrosion.manifest"
+        contentTypeId="org.eclipse.corrosion.toml"
         editorId="org.eclipse.ui.genericeditor.GenericEditor">
    		</editorContentTypeBinding>
    </extension>
@@ -58,7 +65,7 @@
             scopeName="source.toml">
       </grammar>
       <scopeNameContentTypeBinding
-            contentTypeId="org.eclipse.corrosion.manifest"
+            contentTypeId="org.eclipse.corrosion.toml"
             scopeName="source.toml">
       </scopeNameContentTypeBinding>
    </extension>


### PR DESCRIPTION
Signed-off-by: Mickael Istria <mistria@redhat.com>