### PR TITLE
Use better regex in the error line matcher.

### DIFF
--- a/org.eclipse.corrosion/plugin.xml
+++ b/org.eclipse.corrosion/plugin.xml
@@ -411,7 +411,7 @@
        <consolePatternMatchListener
             class="org.eclipse.corrosion.ErrorLineMatcher"
             id="org.eclipse.corrosion.ErrorLineMatcher"
-            regex="(-->).*:\d+:\d+">
+            regex="(?&lt;=-->\s).*:\d+:\d+">
          <enablement>
             <test property="org.eclipse.ui.console.consoleTypeTest" value="org.eclipse.debug.ui.ProcessConsoleType"/>
          </enablement>

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/ErrorLineMatcher.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/ErrorLineMatcher.java
@@ -61,11 +61,11 @@ public class ErrorLineMatcher implements IPatternMatchListenerDelegate {
 						.getAttribute(RustLaunchDelegateTools.PROJECT_ATTRIBUTE, ""); //$NON-NLS-1$
 				IWorkspaceRoot myWorkspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
 				IProject myProject = myWorkspaceRoot.getProject(projectName);
-				String errorString = console.getDocument().get(event.getOffset() + 4, event.getLength() - 4);
+				String errorString = console.getDocument().get(event.getOffset(), event.getLength());
 				String[] coordinates = errorString.split(":"); //$NON-NLS-1$
 				IHyperlink link = makeHyperlink(myProject.getFile(coordinates[0]), Integer.parseInt(coordinates[1]),
 						Integer.parseInt(coordinates[2]));
-				console.addHyperlink(link, offset + 4, length - 4);
+				console.addHyperlink(link, offset, length);
 			}
 		} catch (BadLocationException | CoreException e) {
 			// ignore


### PR DESCRIPTION
Avoids the +/-4 calculations in the code. Thanks Max Bureck for teaching
me.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>