### PR TITLE
Run config now takes environment variable config into account

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/run/CargoRunDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/run/CargoRunDelegate.java
@@ -115,10 +115,11 @@ public class CargoRunDelegate extends LaunchConfigurationDelegate implements ILa
 
 		final List<String> finalRunCommand = cargoRunCommand;
 		final File finalWorkingDirectory = workingDirectory;
+		final String[] envArgs = DebugPlugin.getDefault().getLaunchManager().getEnvironment(configuration);
 		CompletableFuture.runAsync(() -> {
 			try {
 				String[] cmdLine = finalRunCommand.toArray(new String[finalRunCommand.size()]);
-				Process p = DebugPlugin.exec(cmdLine, finalWorkingDirectory);
+				Process p = DebugPlugin.exec(cmdLine, finalWorkingDirectory, envArgs);
 				IProcess process = DebugPlugin.newProcess(launch, p, "cargo run"); //$NON-NLS-1$
 				process.setAttribute(IProcess.ATTR_CMDLINE, String.join(" ", cmdLine)); //$NON-NLS-1$
 			} catch (CoreException e) {


### PR DESCRIPTION
Fixes #269
@akurtakov , @mickaelistria if you know a better way to get to the env variable configuration without using DebugPlugin, let me know.