### PR TITLE
Align target-platform.target with current lsp4e target

### DIFF
--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -15,13 +15,6 @@
 <unit id="org.eclipse.cdt.native.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.launchbar.core" version="0.0.0"/>
 <unit id="org.eclipse.tm.terminal.control" version="0.0.0"/>
-<unit id="org.eclipse.jface.text" version="0.0.0"/>
-<unit id="org.eclipse.jdt.annotation" version="0.0.0"/>
-<unit id="org.eclipse.platform.ide" version="0.0.0"/>
-<unit id="org.eclipse.ui.genericeditor" version="0.0.0"/>
-<unit id="org.junit" version="0.0.0"/>
-<unit id="org.apache.commons.io" version="0.0.0"/>
-<unit id="com.google.gson" version="0.0.0"/>
 <unit id="tm-feature.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/releases/2019-06/"/>
 </location>
@@ -29,5 +22,39 @@
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
 <repository location="http://download.eclipse.org/cbi/updates/license/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="a.jre.javase" version="0.0.0"/>
+<unit id="config.a.jre.javase" version="0.0.0"/>
+<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
+<unit id="org.eclipse.jface.text.tests" version="0.0.0"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.13-I-builds/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.mylyn.commons.notifications.feature.group" version="0.0.0"/>
+<repository location="http://download.eclipse.org/mylyn/releases/latest"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.mylyn.wikitext" version="0.0.0"/>
+<unit id="org.eclipse.mylyn.wikitext.markdown" version="0.0.0"/>
+<unit id="org.eclipse.mylyn.wikitext.markdown.ui" version="0.0.0"/>
+<repository location="http://download.eclipse.org/mylyn/docs/releases/3.0"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.lsp4j" version="0.0.0"/>
+<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
+<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/>
+<unit id="org.eclipse.lsp4j.jsonrpc.debug" version="0.0.0"/>
+<repository location="http://download.eclipse.org/lsp4j/updates/releases/0.7.2/"/>
+<!--repository location="http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/p2-repository/"/-->
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
+<repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.18.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/latest-R/"/>
+</location>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9"/>
 </locations>
 </target>


### PR DESCRIPTION
I have changed the `target-platform` so it is possible to edit and debug Corrosion together with LSP4E in the same workspace.

I don't know of a better way. Suggestions welcome.

Signed-off-by: Nico Orru <nigu.orru@gmail.com>