### PR TITLE
Issue #280 - Update rustup shell script and install RLS by default

### DIFF
--- a/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/TestLSPIntegration.java
+++ b/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/TestLSPIntegration.java
@@ -10,6 +10,7 @@
  * Contributors:
  *  Mickael Istria (Red Hat Inc.) - Source Reference
  *  Lucas Bullen   (Red Hat Inc.) - Initial implementation
+ *  Max Bureck (Fraunhofer FOKUS) - Give RLS more time to generate error
  *******************************************************************************/
 package org.eclipse.corrosion.tests;
 
@@ -35,6 +36,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
@@ -68,17 +70,15 @@ public class TestLSPIntegration extends AbstractCorrosionTest {
 		IEditorPart editor = null;
 		IFile file = project.getFolder("src").getFile("main.rs");
 		editor = IDE.openEditor(activePage, file);
-		new DisplayHelper() {
-			@Override
-			protected boolean condition() {
-				try {
-					return file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO)[0]
-							.getAttribute(IMarker.LINE_NUMBER, -1) == 3;
-				} catch (Exception e) {
-					return false;
-				}
+		Display display = editor.getEditorSite().getShell().getDisplay();
+		DisplayHelper.waitForCondition(display, 50000, () -> {
+			try {
+				return file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO)[0]
+						.getAttribute(IMarker.LINE_NUMBER, -1) == 3;
+			} catch (Exception e) {
+				return false;
 			}
-		}.waitForCondition(editor.getEditorSite().getShell().getDisplay(), 30000);
+		});
 		IMarker[] markers = file.findMarkers(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
 		boolean markerFound = false;
 		for (IMarker marker : markers) {

--- a/org.eclipse.corrosion/pom.xml
+++ b/org.eclipse.corrosion/pom.xml
@@ -23,7 +23,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>https://raw.githubusercontent.com/rust-lang-nursery/rustup.rs/d93c1c83994ae6046a3d9fc0b8f88aed99bacab9/rustup-init.sh</url>
+							<url>https://raw.githubusercontent.com/rust-lang/rustup.rs/1.20.2/rustup-init.sh</url>
 							<outputDirectory>${project.basedir}/scripts</outputDirectory>
 							<skipCache>true</skipCache>
 							<overwrite>true</overwrite>

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/CorrosionPreferencePage.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/CorrosionPreferencePage.java
@@ -10,6 +10,7 @@
  * Contributors:
  *  Lucas Bullen (Red Hat Inc.) - Initial implementation
  *  Nicola Orru - Added support for external RLS startup configuration
+ *  Max Bureck (Fraunhofer FOKUS) - Install rls when installing rustup
  *******************************************************************************/
 package org.eclipse.corrosion;
 
@@ -193,7 +194,7 @@ public class CorrosionPreferencePage extends PreferencePage implements IWorkbenc
 			return false;
 		}
 		String[] rlsPath = new String[] { varParse(rustupInput.getValue()), "run", getToolchainId(), "rls" }; //$NON-NLS-1$ //$NON-NLS-2$
-		
+
 		if (!CorrosionPlugin.validateCommandVersion(rlsPath, RustManager.RLS_VERSION_FORMAT_PATTERN)) {
 			setErrorMessage(Messages.CorrosionPreferencePage_rustupMissingRLS);
 			setInstallRequired(true);
@@ -429,7 +430,7 @@ public class CorrosionPreferencePage extends PreferencePage implements IWorkbenc
 						Messages.CorrosionPreferencePage_cannotInstallRustupCargo_details);
 				return;
 			}
-			command = new String[] { file.getAbsolutePath() + " -y" }; //$NON-NLS-1$
+			command = new String[] { file.getAbsolutePath(), "-y", "-c", "rls" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		} catch (IOException | URISyntaxException e) {
 			CorrosionPlugin.showError(Messages.CorrosionPreferencePage_cannotInstallRustupCargo,
 					Messages.CorrosionPreferencePage_cannotInstallRustupCargo_details, e);


### PR DESCRIPTION
- Updated rustup shell script to current version 1.20.2 see CQ:
  https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21017
- Updated call to script to install the rls component with rustup

Signed-off-by: Max Bureck <max.bureck@fokus.fraunhofer.de>