### PR TITLE
Issue #278 "Run test" CodeMining

### DIFF
--- a/org.eclipse.corrosion.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.corrosion.tests/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.corrosion.tests;singleton:=true
 Bundle-Version: 0.4.3.qualifier
 Bundle-Vendor: %Bundle-Vendor
+Fragment-Host: org.eclipse.corrosion
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.corrosion.tests
 Require-Bundle: org.eclipse.corrosion;bundle-version="0.1.0",

--- a/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/launch/CargoArgsTest.java
+++ b/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/launch/CargoArgsTest.java
@@ -1,0 +1,129 @@
+/*********************************************************************
+ * Copyright (c) 2019 Fraunhofer FOKUS and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Max Bureck (Fraunhofer FOKUS) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.launch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+public class CargoArgsTest {
+
+	private static final String SEPARATOR = "--";
+
+	@Test
+	public void testOnlyCommand() {
+		String command = "fmt";
+		String[] input = { command };
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+		assertEquals(command, result.command);
+		assertTrue(result.arguments.isEmpty());
+		assertTrue(result.options.isEmpty());
+	}
+
+	@Test
+	public void testOnlyCommandAndSeparator() {
+		String command = "fmt";
+		String[] input = { command, SEPARATOR };
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+		assertEquals(command, result.command);
+		assertTrue(result.arguments.isEmpty());
+		assertTrue(result.options.isEmpty());
+	}
+
+	@Test
+	public void testOnlyCommandAndOptions() {
+		String command = "build";
+		String opt1 = "--all";
+		String opt2 = "--release";
+		String[] input = { command, opt1, opt2 };
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+		assertEquals(command, result.command);
+		assertEquals(Arrays.asList(opt1, opt2), result.options);
+		assertTrue(result.arguments.isEmpty());
+	}
+
+	@Test
+	public void testOnlyCommandAndOptionsAndSeparator() {
+		String command = "build";
+		String opt1 = "--all";
+		String opt2 = "--release";
+		String[] input = { command, opt1, opt2, SEPARATOR };
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+		assertEquals(command, result.command);
+		assertEquals(Arrays.asList(opt1, opt2), result.options);
+		assertTrue(result.arguments.isEmpty());
+	}
+
+	@Test
+	public void testOnlyCommandAndArguments() {
+		String command = "build";
+		List<String> arguments = Arrays.asList("--nocapture", "my_test");
+
+		List<String> all_arguments = new ArrayList<>();
+		all_arguments.add(command);
+		all_arguments.add(SEPARATOR);
+		all_arguments.addAll(arguments);
+		String[] input = all_arguments.toArray(new String[] {});
+
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+
+		assertEquals(command, result.command);
+		assertTrue(result.options.isEmpty());
+		assertEquals(arguments, result.arguments);
+	}
+
+	@Test
+	public void testOnlyCommandAndOptionsAndArguments() {
+		String command = "build";
+		List<String> options = Arrays.asList("--all", "--release");
+		List<String> arguments = Arrays.asList("--nocapture", "my_test");
+
+		List<String> all_arguments = new ArrayList<>();
+		all_arguments.add(command);
+		all_arguments.addAll(options);
+		all_arguments.add(SEPARATOR);
+		all_arguments.addAll(arguments);
+		String[] input = all_arguments.toArray(new String[] {});
+
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+
+		assertEquals(command, result.command);
+		assertEquals(options, result.options);
+		assertEquals(arguments, result.arguments);
+	}
+
+	@Test
+	public void testOnlyCommandAndOptionsAndArgumentsIncludingSeparator() {
+		String command = "build";
+		List<String> options = Arrays.asList("--all", "--release");
+		List<String> arguments = Arrays.asList("--nocapture", SEPARATOR, "my_test");
+
+		List<String> all_arguments = new ArrayList<>();
+		all_arguments.add(command);
+		all_arguments.addAll(options);
+		all_arguments.add(SEPARATOR);
+		all_arguments.addAll(arguments);
+		String[] input = all_arguments.toArray(new String[] {});
+
+		CargoArgs result = CargoArgs.fromAllArguments(input);
+
+		assertEquals(command, result.command);
+		assertEquals(options, result.options);
+		assertEquals(arguments, result.arguments);
+	}
+}

--- a/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/launch/RLSRunCommandTest.java
+++ b/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/launch/RLSRunCommandTest.java
@@ -1,0 +1,158 @@
+/*********************************************************************
+ * Copyright (c) 2019 Fraunhofer FOKUS and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Max Bureck (Fraunhofer FOKUS) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.launch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.lsp4j.Command;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+public class RLSRunCommandTest {
+
+	private static final String TITLE = "Run test";
+	private static final String COMMAND_ID = "rls.run";
+
+	// Test data
+	private static final String VALID_BINARY = "cargo";
+	private static final List<String> VALID_ARGS = Arrays.asList("--release");
+	private static final List<String> EMPTY_ARGS = Collections.emptyList();
+	private static final Map<String, String> VALID_ENV = Collections.singletonMap("RUST_BACKTRACE", "short");
+	private static final Map<String, String> EMPTY_ENV = Collections.emptyMap();
+
+	@RunWith(Parameterized.class)
+	public static class MissingField {
+		private String binary;
+		private List<String> arguments;
+		private Map<String, String> environment;
+
+		public MissingField(String binary, List<String> arguments, Map<String, String> environment) {
+			super();
+			this.binary = binary;
+			this.arguments = arguments;
+			this.environment = environment;
+		}
+
+		@Parameters
+		public static Collection<Object[]> parameters() {
+			return Arrays.asList(new Object[][] { 
+				{ VALID_BINARY, null, null }, 
+				{ null, VALID_ARGS, null },
+				{ null, null, VALID_ENV }, 
+				{ VALID_BINARY, VALID_ARGS, null }, 
+				{ null, VALID_ARGS, VALID_ENV },
+				{ VALID_BINARY, null, VALID_ENV }, 
+			});
+		}
+
+		@Test
+		public void testMapEntryArgument() {
+			Map<String, Object> argument = createArgument(binary, arguments, environment);
+			Command command = new Command(TITLE, COMMAND_ID, Arrays.asList(argument));
+			Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+			assertFalse(lspCommand.isPresent());
+		}
+	}
+
+	@Test
+	public void testNoArgument() {
+		Command command = new Command(TITLE, COMMAND_ID, Arrays.asList());
+		Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+		assertFalse(lspCommand.isPresent());
+	}
+
+	@Test
+	public void testArgumentListNull() {
+		Command command = new Command(TITLE, COMMAND_ID, null);
+		Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+		assertFalse(lspCommand.isPresent());
+	}
+
+	@Test
+	public void testArgumentListWrongEntry() {
+		Command command = new Command(TITLE, COMMAND_ID, Arrays.asList("foo"));
+		Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+		assertFalse(lspCommand.isPresent());
+	}
+
+	@Test
+	public void testEmptyArguments() {
+		Command command = new Command(TITLE, COMMAND_ID,
+				Arrays.asList(createArgument(VALID_BINARY, EMPTY_ARGS, EMPTY_ENV)));
+		Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+
+		assertTrue(lspCommand.isPresent());
+		RLSRunCommand runCommand = lspCommand.get();
+		assertEquals(0, runCommand.args.length);
+		assertTrue(runCommand.env.isEmpty());
+	}
+
+	@Test
+	public void testValidArguments() {
+		Command command = new Command(TITLE, COMMAND_ID,
+				Arrays.asList(createArgument(VALID_BINARY, VALID_ARGS, VALID_ENV)));
+		Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+
+		assertTrue(lspCommand.isPresent());
+		RLSRunCommand runCommand = lspCommand.get();
+		assertEquals(VALID_ARGS, Arrays.asList(runCommand.args));
+		assertEquals(VALID_ENV, runCommand.env);
+	}
+
+	@Test
+	public void testInvalidEnvEntry() {
+		Map<String, String> env = new HashMap<>();
+		env.put("INVALID", null);
+		env.put("RUST_BACKTRACE", "short");
+		env.put(null, "INVALID_KEY");
+
+		Command command = new Command(TITLE, COMMAND_ID, Arrays.asList(createArgument(VALID_BINARY, VALID_ARGS, env)));
+		Optional<RLSRunCommand> lspCommand = RLSRunCommand.fromLSPCommand(command);
+
+		assertTrue(lspCommand.isPresent());
+		RLSRunCommand runCommand = lspCommand.get();
+		assertEquals(VALID_ENV, runCommand.env);
+	}
+
+	private static Map<String, Object> createArgument(String binary, List<String> arguments,
+			Map<String, String> environment) {
+		Map<String, Object> result = new HashMap<>();
+
+		if (binary != null) {
+			result.put("binary", binary);
+		}
+
+		if (arguments != null) {
+			result.put("args", arguments);
+		}
+
+		if (environment != null) {
+			result.put("env", environment);
+		}
+
+		return result;
+	}
+
+}

--- a/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/AllTests.java
+++ b/org.eclipse.corrosion.tests/src/org/eclipse/corrosion/tests/AllTests.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.eclipse.corrosion.tests;
 
+import org.eclipse.corrosion.launch.CargoArgsTest;
+import org.eclipse.corrosion.launch.RLSRunCommandTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -26,7 +28,10 @@ import org.junit.runners.Suite.SuiteClasses;
 	TestDebugConfiguration.class,
 	TestExportCargoProjectWizard.class,
 	TestLSPExtensions.class,
-	TestSnippetContentAssistProcessor.class
+	TestSnippetContentAssistProcessor.class,
+	CargoArgsTest.class,
+	RLSRunCommandTest.class,
+	RLSRunCommandTest.MissingField.class
 })
 public class AllTests {
 

--- a/org.eclipse.corrosion/plugin.xml
+++ b/org.eclipse.corrosion/plugin.xml
@@ -424,5 +424,12 @@
             icon="icons/rustEditorIcon.png">
       </icon>
    </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="org.eclipse.corrosion.launch.LaunchHandler"
+            commandId="rls.run">
+      </handler>
+   </extension>
 
 </plugin>

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/ErrorLineMatcher.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/ErrorLineMatcher.java
@@ -60,7 +60,7 @@ public class ErrorLineMatcher implements IPatternMatchListenerDelegate {
 				ILaunch launch = process.getLaunch();
 				String projectAttribute = RustLaunchDelegateTools.PROJECT_ATTRIBUTE;
 				String launchConfigurationType = launch.getLaunchConfiguration().getType().getIdentifier();
-				if (launchConfigurationType.equals("org.eclipse.corrosion.debug.RustDebugDelegate")) { //$NON-NLS-1$
+				if (launchConfigurationType.equals(RustLaunchDelegateTools.CORROSION_DEBUG_LAUNCH_CONFIG_TYPE)) {
 					// support debug launch configs
 					projectAttribute = ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME;
 				}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/Messages.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/Messages.java
@@ -169,4 +169,9 @@ public class Messages extends NLS {
 	public static String CargoRunTab_Title;
 	public static String CargoTestTab_Title;
 	public static String RustDebugTabGroup_gdbErrorMsg;
+	public static String LaunchHandler_unableToLaunch;
+	public static String LaunchHandler_launchingFromCargoRegistryUnsupported;
+	public static String LaunchHandler_unsupportedProjectLocation;
+	public static String LaunchHandler_unableToLaunchCommand;
+
 }

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/debug/RustDebugDelegate.java
@@ -198,7 +198,7 @@ public class RustDebugDelegate extends GdbLaunchDelegate implements ILaunchShort
 
 	private static ILaunchConfiguration getLaunchConfiguration(IResource resource) {
 		ILaunchConfiguration launchConfiguration = RustLaunchDelegateTools.getLaunchConfiguration(resource,
-				"org.eclipse.corrosion.debug.RustDebugDelegate"); //$NON-NLS-1$
+				RustLaunchDelegateTools.CORROSION_DEBUG_LAUNCH_CONFIG_TYPE);
 		if (launchConfiguration instanceof ILaunchConfigurationWorkingCopy) {
 			ILaunchConfigurationWorkingCopy wc = (ILaunchConfigurationWorkingCopy) launchConfiguration;
 			final IProject project = resource.getProject();

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/edit/RLSStreamConnectionProvider.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/edit/RLSStreamConnectionProvider.java
@@ -34,6 +34,8 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
@@ -84,10 +86,18 @@ public class RLSStreamConnectionProvider implements StreamConnectionProvider {
 		hasCancelledSetup = newValue;
 	}
 
+	@Override
+	public void handleMessage(Message message, LanguageServer languageServer, URI rootURI) {
+		// System.out.println(message);
+	}
+
 	private static Map<String, Object> getDefaultInitializationOptions() {
-		final Map<String, Object> initializationSettings = new HashMap<>();
-		initializationSettings.put("clippy_preference", "on"); //$NON-NLS-1$//$NON-NLS-2$
-		return Collections.singletonMap("settings", Collections.singletonMap("rust", initializationSettings)); //$NON-NLS-1$ //$NON-NLS-2$
+		final Map<String, Object> initializationOptions = new HashMap<>();
+		final Map<String, Object> rustInitializationSettings = new HashMap<>();
+		rustInitializationSettings.put("clippy_preference", "on"); //$NON-NLS-1$//$NON-NLS-2$
+		initializationOptions.put("settings", Collections.singletonMap("rust", rustInitializationSettings)); //$NON-NLS-1$ //$NON-NLS-2$
+		initializationOptions.put("cmdRun", true); //$NON-NLS-1$
+		return initializationOptions;
 	}
 
 	@Override

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/CargoArgs.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/CargoArgs.java
@@ -1,0 +1,88 @@
+/*********************************************************************
+ * Copyright (c) 2019 Fraunhofer FOKUS and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Max Bureck (Fraunhofer FOKUS) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.launch;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class represents arguments to cargo. This consist of the command (e.g.
+ * "test" or "run"), the options (flags for the command) and arguments (to be
+ * passed to the executable called by cargo). Instances of this class can be
+ * created via the static factory method
+ * {@link CargoArgs#fromAllArguments(String[])}.
+ */
+class CargoArgs {
+	public final List<String> options;
+	public final List<String> arguments;
+	public final String command;
+
+	private CargoArgs(List<String> options, List<String> arguments, String command) {
+		super();
+		this.options = options;
+		this.arguments = arguments;
+		this.command = command;
+	}
+
+	/**
+	 * This static factory method splits the given {@code args} by expecting the
+	 * following argument pattern:
+	 * {@code [OMITTED] COMMAND [OPTIONS] [-- ARGS]}.<br>
+	 * Where:
+	 * <ul>
+	 * <li>{@code OMITTED} are flags starting with {@code "-"}, which are
+	 * omitted</li>
+	 * <li>{@code COMMAND} is the cargo command (e.g "test" or "run")</li>
+	 * <li>{@code OPTIONS} are flags for the cargo command</li>
+	 * <li>{@code ARGS} are arguments passed to the program called by cargo</li>
+	 * </ul>
+	 * This pattern is a heuristic for most cargo commands, it may be updated to
+	 * support different command structures.
+	 *
+	 * @param args all arguments after a sub-command (e.g. )
+	 * @return instance of {@code CargoArgs} holding command, options and arguments
+	 */
+	public static CargoArgs fromAllArguments(String[] args) {
+
+		String resultCommand = ""; //$NON-NLS-1$
+		List<String> resultOptions = Collections.emptyList();
+		List<String> resultArguments = Collections.emptyList();
+
+		int startIndex = 0;
+		for (String arg : args) {
+			startIndex++;
+			// skip starting flags
+			if (!arg.startsWith("-")) { //$NON-NLS-1$
+				resultCommand = arg;
+				break;
+			}
+		}
+
+		int length = args.length;
+		if (startIndex < length - 1) {
+			List<String> argsList = Arrays.asList(args);
+			int separatorIndex = argsList.indexOf("--"); //$NON-NLS-1$
+			if (separatorIndex < 0) {
+				resultOptions = argsList.subList(startIndex, length);
+			} else {
+				resultOptions = argsList.subList(startIndex, separatorIndex);
+				if (separatorIndex < length - 1) {
+					resultArguments = argsList.subList(separatorIndex + 1, length);
+				}
+			}
+		}
+		return new CargoArgs(resultOptions, resultArguments, resultCommand);
+	}
+	// foo
+}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/LaunchHandler.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/LaunchHandler.java
@@ -1,0 +1,263 @@
+/*********************************************************************
+ * Copyright (c) 2019 Fraunhofer FOKUS and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Max Bureck (Fraunhofer FOKUS) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.launch;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.corrosion.CorrosionPlugin;
+import org.eclipse.corrosion.Messages;
+import org.eclipse.corrosion.test.CargoTestDelegate;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.lsp4e.command.LSPCommandHandler;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * Handler for {@code rls.run} RLS LSP command ID.
+ */
+@SuppressWarnings("restriction") // We know we are using an unstable LSP4E feature
+public class LaunchHandler extends LSPCommandHandler {
+
+	private static final Pattern ENV_SPLITTER = Pattern.compile("="); //$NON-NLS-1$
+	private static final Predicate<String> NOT_EMPTY = not(String::isEmpty);
+
+	private static <T> Predicate<T> not(Predicate<T> p) {
+		return p.negate();
+	}
+
+	@Override
+	public Object execute(ExecutionEvent event, Command command, IPath context) throws ExecutionException {
+		// Note that this check must change if we don't import the .cargo project
+		// anymore
+		IPath cargoRegistry = new Path("/.cargo/registry"); //$NON-NLS-1$
+		if (cargoRegistry.isPrefixOf(context)) {
+			RustLaunchDelegateTools.openError(Messages.LaunchHandler_unableToLaunch,
+					Messages.LaunchHandler_launchingFromCargoRegistryUnsupported);
+			return null;
+		}
+
+		Optional<RLSRunCommand> runCommand = RLSRunCommand.fromLSPCommand(command);
+		if (!runCommand.isPresent()) {
+			// RLS sent unknown command format, we cannot give advice to user, just log
+			// the error
+			String msg = NLS.bind(Messages.LaunchHandler_unableToLaunchCommand, command);
+			CorrosionPlugin.logError(new Status(IStatus.ERROR, CorrosionPlugin.PLUGIN_ID, msg));
+		}
+
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getFile(context).getProject();
+		if (project.exists()) {
+			Optional<RLSRunCommand> cargoRunCommand = runCommand.filter(LaunchHandler::isCargoBin)
+					.filter(LaunchHandler::isTestArg);
+			cargoRunCommand.ifPresent(c -> createAndStartCargoTest(c, project));
+
+			if (!cargoRunCommand.isPresent()) {
+				// If command is not present, we have RLS command we don't know how to execute.
+				// We cannot give user advice on what to do, just log the error
+				String msg = NLS.bind(Messages.LaunchHandler_unableToLaunchCommand, command);
+				CorrosionPlugin.logError(new Status(IStatus.ERROR, CorrosionPlugin.PLUGIN_ID, msg));
+			}
+
+			return null;
+		}
+		RustLaunchDelegateTools.openError(Messages.LaunchHandler_unableToLaunch,
+				Messages.LaunchHandler_unsupportedProjectLocation);
+
+		// TODO if no project, let's find the parent folder of context that contains a
+		// Cargo.toml file.
+
+		// TODO: if not cargo test, then run with external tool launch in context of
+		// project/folder of context. Since the RLS currently only creates commands for
+		// "cargo test", this is not urgent.
+		return null;
+	}
+
+	private static boolean isCargoBin(RLSRunCommand command) {
+		return Objects.equals(command.binary, "cargo") || Objects.equals(command.binary, "cargo.exe"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static boolean isTestArg(RLSRunCommand runCommand) {
+		return runCommand.args.length > 0 && Objects.equals(runCommand.args[0], "test"); //$NON-NLS-1$
+	}
+
+	/**
+	 * Looks up an existing cargo test launch configuration with the arguments
+	 * specified in {@code command} for the given {@code project}. If no such launch
+	 * configuration exists, creates a new one. The launch configuration is then
+	 * run.
+	 *
+	 * @param command rls.run command with all information needed to run cargo test
+	 * @param project the context project for which the launch configuration is
+	 *                looked up / created
+	 */
+	private static void createAndStartCargoTest(RLSRunCommand command, IProject project) {
+		CargoArgs args = CargoArgs.fromAllArguments(command.args);
+		Map<String, String> envMap = command.env;
+
+		ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
+		ILaunchConfigurationType type = manager
+				.getLaunchConfigurationType(CargoTestDelegate.CARGO_TEST_LAUNCH_CONFIG_TYPE_ID);
+		try {
+			// check if launch config already exists
+			ILaunchConfiguration[] launchConfigurations = manager.getLaunchConfigurations(type);
+
+			Set<Entry<String, String>> envMapEntries = envMap.entrySet();
+			// prefer running existing launch configuration with same parameters
+			ILaunchConfiguration launchConfig = Arrays.stream(launchConfigurations)
+					.filter((l) -> matchesTestLaunchConfig(l, project, args, envMapEntries)).findAny()
+					.orElseGet(() -> createCargoLaunchConfig(manager, type, project, args, envMap));
+
+			if (launchConfig != null) {
+				DebugUITools.launch(launchConfig, ILaunchManager.RUN_MODE);
+			}
+		} catch (CoreException e) {
+			CorrosionPlugin.logError(e);
+		}
+	}
+
+	/**
+	 * This method can be used to create cargo test or cargo run launch
+	 * configurations (depending on the {@code cargoLaunchType} argument). The
+	 * attributes of the returned launch configuration will be set based on the
+	 * information passed in as parameters.
+	 *
+	 * @param manager         is used to create the launch config
+	 * @param cargoLaunchType determines which type of launch config to create
+	 * @param project         the cargo project in the workspace, the launch config
+	 *                        is created for.
+	 * @param args            arguments to cargo
+	 * @param envMap          environment variables to be set for the launch
+	 *                        configuration
+	 * @return a new launch configuration, based on the given parameters
+	 */
+	private static ILaunchConfiguration createCargoLaunchConfig(ILaunchManager manager,
+			ILaunchConfigurationType cargoLaunchType, IProject project, CargoArgs args, Map<String, String> envMap) {
+		try {
+			String projectName = project.getName();
+			String optionsString = toSpaceSeparatedString(args.options);
+			String argumentsString = toSpaceSeparatedString(args.arguments);
+			String launchConfigName = createLaunchConfigName(manager, projectName, args.command, optionsString,
+					argumentsString);
+
+			ILaunchConfigurationWorkingCopy launchWorkingCopy = cargoLaunchType.newInstance(null, launchConfigName);
+			launchWorkingCopy.setAttribute(RustLaunchDelegateTools.PROJECT_ATTRIBUTE, projectName);
+			launchWorkingCopy.setAttribute(RustLaunchDelegateTools.OPTIONS_ATTRIBUTE, optionsString);
+			launchWorkingCopy.setAttribute(RustLaunchDelegateTools.ARGUMENTS_ATTRIBUTE, argumentsString);
+			launchWorkingCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, envMap);
+			launchWorkingCopy.setAttribute(RustLaunchDelegateTools.WORKING_DIRECTORY_ATTRIBUTE, projectName);
+
+			// we currently do not call launchWorkingCopy.doSave(), since in practice it
+			// would clutter the workspace with launch configurations. Maybe at some point
+			// in time we may add the ability for the user to make the launch configuration
+			// persistent (e.g. by holing CTRL on click, or whatever is possible).
+			return launchWorkingCopy;
+		} catch (CoreException e) {
+			CorrosionPlugin.logError(e);
+			return null;
+		}
+	}
+
+	private static String toSpaceSeparatedString(List<String> strings) {
+		return strings.stream().collect(Collectors.joining(" ")); //$NON-NLS-1$
+	}
+
+	private static String createLaunchConfigName(ILaunchManager manager, String projectName, String command,
+			String optionsString, String argumentsString) {
+		String nameSuffix = Stream.of(command, optionsString, "--", argumentsString).filter(NOT_EMPTY) //$NON-NLS-1$
+				.collect(Collectors.joining(" ", " [", "]")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ ;
+		String nameWithSuffix = projectName + nameSuffix;
+		String result = manager.generateLaunchConfigurationName(nameWithSuffix);
+		return result;
+	}
+
+	private static boolean matchesTestLaunchConfig(ILaunchConfiguration launchConfig, IProject cmdProject,
+			CargoArgs cmdArgs, Set<Entry<String, String>> cmdEnvEntries) {
+		try {
+			String project = launchConfig.getAttribute(RustLaunchDelegateTools.PROJECT_ATTRIBUTE, ""); //$NON-NLS-1$
+			if (!project.equals(cmdProject.getName())) {
+				return false;
+			}
+
+			String optionsStr = launchConfig.getAttribute(RustLaunchDelegateTools.OPTIONS_ATTRIBUTE, ""); //$NON-NLS-1$
+			String[] options = {};
+			if (!optionsStr.isEmpty()) {
+				options = substituteVariablesAndSplit(optionsStr);
+			}
+			if (!cmdArgs.options.equals(Arrays.asList(options))) {
+				return false;
+			}
+
+			String argumentsStr = launchConfig.getAttribute(RustLaunchDelegateTools.ARGUMENTS_ATTRIBUTE, ""); //$NON-NLS-1$
+			String[] arguments = {};
+			if (!argumentsStr.isEmpty()) {
+				arguments = substituteVariablesAndSplit(argumentsStr);
+			}
+			if (!cmdArgs.arguments.equals(Arrays.asList(arguments))) {
+				return false;
+			}
+
+			final String[] envArgs = DebugPlugin.getDefault().getLaunchManager().getEnvironment(launchConfig);
+			Set<Entry<String, String>> envEntries = Collections.emptySet();
+			if (envArgs != null) {
+				envEntries = Arrays.stream(envArgs).map(LaunchHandler::splitToEntry).collect(Collectors.toSet());
+			}
+			if (!envEntries.containsAll(cmdEnvEntries)) {
+				return false;
+			}
+
+			// Project, options, test arguments, and environment variables match
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	private static String[] substituteVariablesAndSplit(String argumentsStr) throws CoreException {
+		return RustLaunchDelegateTools.performVariableSubstitution(argumentsStr).split("\\s+"); //$NON-NLS-1$
+	}
+
+	private static Entry<String, String> splitToEntry(String s) {
+		String[] split = ENV_SPLITTER.split(s, 2);
+		String key = split[0];
+		String value = ""; //$NON-NLS-1$
+		if (split.length > 1) {
+			value = split[1];
+		}
+		return new SimpleEntry<>(key, value);
+	}
+}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RLSRunCommand.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RLSRunCommand.java
@@ -1,0 +1,95 @@
+/*********************************************************************
+ * Copyright (c) 2019 Fraunhofer FOKUS and others.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Max Bureck (Fraunhofer FOKUS) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.corrosion.launch;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.lsp4j.Command;
+
+/**
+ * Class holding all information of the {@code rls.run} RLS LSP command.
+ * Instances can be read from {@link Command} objects using the
+ * {@link RLSRunCommand#fromLSPCommand(Command)}.
+ */
+class RLSRunCommand {
+
+	public final String binary;
+	public final Map<String, String> env;
+	public final String[] args;
+
+	private RLSRunCommand(String binary, Map<String, String> env, String[] args) {
+		super();
+		this.binary = binary;
+		this.env = env;
+		this.args = args;
+	}
+
+	/**
+	 * Creates an {@link RLSRunCommand} if the given {@code command} contains all
+	 * information needed for creating one. If all information is available, the
+	 * returned {@code Option} will contain an instance of {@code RLSRunCommand},
+	 * otherwise the returned {@code Option} will be empty.
+	 *
+	 * @param command the LSP command used to read all information needed for the
+	 *                resulting {@link RLSRunCommand}
+	 * @return if all information available for creating a {@code RLSRunCommand},
+	 *         the {@code Optional} will hold a value, otherwise the returned
+	 *         {@code Optional} will be empty.
+	 */
+	public static Optional<RLSRunCommand> fromLSPCommand(Command command) {
+		List<Object> arguments = command.getArguments();
+		if (arguments == null || arguments.size() < 1) {
+			return Optional.empty();
+		}
+
+		Object argumentsObj = arguments.get(0);
+		Map<?, ?> argMap = castOrNull(argumentsObj, Map.class);
+		if (argMap == null) {
+			return Optional.empty();
+		}
+
+		Object binaryObj = argMap.get("binary"); //$NON-NLS-1$
+		if (binaryObj == null) {
+			return Optional.empty();
+		}
+		String binary = Objects.toString(binaryObj);
+
+		List<?> argsObj = castOrNull(argMap.get("args"), List.class); //$NON-NLS-1$
+		if (argsObj == null) {
+			return Optional.empty();
+		}
+		String[] args = argsObj.stream().filter(String.class::isInstance).map(String.class::cast)
+				.toArray(String[]::new);
+
+		Map<?, ?> envObjsMap = castOrNull(argMap.get("env"), Map.class); //$NON-NLS-1$
+		if (envObjsMap == null) {
+			return Optional.empty();
+		}
+		Map<String, String> envMap = envObjsMap.entrySet().stream()
+				.filter(e -> e.getKey() != null && e.getValue() != null)
+				.collect(Collectors.toMap(e -> Objects.toString(e.getKey()), e -> Objects.toString(e.getValue())));
+
+		return Optional.of(new RLSRunCommand(binary, envMap, args));
+	}
+
+	private static <T> T castOrNull(Object o, Class<T> clazz) {
+		if (!clazz.isInstance(o)) {
+			return null;
+		}
+		return clazz.cast(o);
+	}
+}

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/launch/RustLaunchDelegateTools.java
@@ -39,6 +39,7 @@ import org.eclipse.ui.PlatformUI;
 
 public class RustLaunchDelegateTools {
 
+	public static final String CORROSION_DEBUG_LAUNCH_CONFIG_TYPE = "org.eclipse.corrosion.debug.RustDebugDelegate"; //$NON-NLS-1$
 	public static final String PROJECT_ATTRIBUTE = "PROJECT"; //$NON-NLS-1$
 	public static final String OPTIONS_ATTRIBUTE = "OPTIONS"; //$NON-NLS-1$
 	public static final String ARGUMENTS_ATTRIBUTE = "ARGUMENTS"; //$NON-NLS-1$
@@ -133,7 +134,7 @@ public class RustLaunchDelegateTools {
 			ILaunchConfiguration[] launchConfigurations = launchManager.getLaunchConfigurations(configType);
 			final String projectName = resource.getProject().getName();
 			String launchConfigProjectAttribute;
-			if (launchConfigurationType.equals("org.eclipse.corrosion.debug.RustDebugDelegate")) { //$NON-NLS-1$
+			if (launchConfigurationType.equals(CORROSION_DEBUG_LAUNCH_CONFIG_TYPE)) {
 				launchConfigProjectAttribute = ICDTLaunchConfigurationConstants.ATTR_PROJECT_NAME;
 			} else {
 				launchConfigProjectAttribute = RustLaunchDelegateTools.PROJECT_ATTRIBUTE;

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/messages.properties
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/messages.properties
@@ -158,3 +158,7 @@ RustManager_toolchainDoesntIncludeRLS=The toolchain `{0}` does not contain the R
 CargoRunTab_Title=Main
 CargoTestTab_Title=Main
 RustDebugTabGroup_gdbErrorMsg={0} [cause: {1}]
+LaunchHandler_unableToLaunch=Unable to Launch
+LaunchHandler_launchingFromCargoRegistryUnsupported=Launching from the central cargo registry is not supported.
+LaunchHandler_unsupportedProjectLocation=Unsupported project location. The project must be imported as an Eclipse project.
+LaunchHandler_unableToLaunchCommand=Unable to launch command: {0}.

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/run/CargoRunDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/run/CargoRunDelegate.java
@@ -40,6 +40,8 @@ import org.eclipse.ui.IEditorPart;
 
 public class CargoRunDelegate extends LaunchConfigurationDelegate implements ILaunchShortcut {
 
+	public static final String CARGO_RUN_LAUNCH_CONFIG_TYPE = "org.eclipse.corrosion.run.CargoRunDelegate"; //$NON-NLS-1$
+
 	@Override
 	public void launch(ISelection selection, String mode) {
 		ILaunchConfiguration launchConfig = getLaunchConfiguration(
@@ -133,7 +135,7 @@ public class CargoRunDelegate extends LaunchConfigurationDelegate implements ILa
 
 	private static ILaunchConfiguration getLaunchConfiguration(IResource resource) {
 		ILaunchConfiguration launchConfiguration = RustLaunchDelegateTools.getLaunchConfiguration(resource,
-				"org.eclipse.corrosion.run.CargoRunDelegate"); //$NON-NLS-1$
+				CARGO_RUN_LAUNCH_CONFIG_TYPE);
 		if (launchConfiguration instanceof ILaunchConfigurationWorkingCopy) {
 			ILaunchConfigurationWorkingCopy wc = (ILaunchConfigurationWorkingCopy) launchConfiguration;
 			wc.setAttribute(RustLaunchDelegateTools.PROJECT_ATTRIBUTE, resource.getProject().getName());

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/test/CargoTestDelegate.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/test/CargoTestDelegate.java
@@ -39,6 +39,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.IEditorPart;
 
 public class CargoTestDelegate extends LaunchConfigurationDelegate implements ILaunchShortcut {
+	public static final String CARGO_TEST_LAUNCH_CONFIG_TYPE_ID = "org.eclipse.corrosion.test.CargoTestDelegate"; //$NON-NLS-1$
 	public static final String TEST_NAME_ATTRIBUTE = "TEST_NAME"; //$NON-NLS-1$
 
 	@Override
@@ -120,10 +121,11 @@ public class CargoTestDelegate extends LaunchConfigurationDelegate implements IL
 
 		final List<String> finalTestCommand = cargoTestCommand;
 		final File finalWorkingDirectory = workingDirectory;
+		final String[] envArgs = DebugPlugin.getDefault().getLaunchManager().getEnvironment(configuration);
 		CompletableFuture.runAsync(() -> {
 			try {
 				String[] cmdLine = finalTestCommand.toArray(new String[finalTestCommand.size()]);
-				Process p = DebugPlugin.exec(cmdLine, finalWorkingDirectory);
+				Process p = DebugPlugin.exec(cmdLine, finalWorkingDirectory, envArgs);
 				IProcess process = DebugPlugin.newProcess(launch, p, "cargo test"); //$NON-NLS-1$
 				process.setAttribute(IProcess.ATTR_CMDLINE, String.join(" ", cmdLine)); //$NON-NLS-1$
 			} catch (CoreException e) {
@@ -137,7 +139,7 @@ public class CargoTestDelegate extends LaunchConfigurationDelegate implements IL
 
 	private static ILaunchConfiguration getLaunchConfiguration(IResource resource) {
 		ILaunchConfiguration launchConfiguration = RustLaunchDelegateTools.getLaunchConfiguration(resource,
-				"org.eclipse.corrosion.test.CargoTestDelegate"); //$NON-NLS-1$
+				CARGO_TEST_LAUNCH_CONFIG_TYPE_ID);
 		if (launchConfiguration instanceof ILaunchConfigurationWorkingCopy) {
 			ILaunchConfigurationWorkingCopy wc = (ILaunchConfigurationWorkingCopy) launchConfiguration;
 			wc.setAttribute(RustLaunchDelegateTools.PROJECT_ATTRIBUTE, resource.getProject().getName());


### PR DESCRIPTION
Added LaunchHandler to handle RLS "rls.run" LSP commands. These
are attached to the "Run test" CodeLens message. And invoked by the
user by clicking on the CodeMining created for the CodeLens.

The LaunchHandler will try to find a cargo test launch config for the
command parameters, if no launch config is found, it a new launch config
will be created (but not saved). The launch config will then be started.