### PR TITLE
Implement "sourround with" style templates

### DIFF
--- a/org.eclipse.corrosion/snippets/rust.json
+++ b/org.eclipse.corrosion/snippets/rust.json
@@ -74,8 +74,15 @@
         "completionItemKind": 15,
         "replacementLines": [
             "thread::spawn(move || {",
-            "    $0",
+            "    ${0:$TM_SELECTED_TEXT}",
             "});"
+        ]
+    },
+    {
+    	"display": "dbg!",
+        "completionItemKind": 15,
+        "replacementLines": [
+            "dbg!(${0:$TM_SELECTED_TEXT})"
         ]
     }
 ]

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/snippet/SnippetContentAssistProcessor.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/snippet/SnippetContentAssistProcessor.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *  Lucas Bullen (Red Hat Inc.) - Initial implementation
+ *  Max Bureck (Fraunhofer FOKUS) - Implemented "surround with" style snippets
  *******************************************************************************/
 package org.eclipse.corrosion.snippet;
 
@@ -20,21 +21,28 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.corrosion.CorrosionPlugin;
+import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.ITextViewerExtension9;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.LanguageServiceAccessor.LSPDocumentInfo;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -98,16 +106,69 @@ public class SnippetContentAssistProcessor implements IContentAssistProcessor {
 		String indent = matcher.group("indent"); //$NON-NLS-1$
 		String prefix = matcher.group("prefix"); //$NON-NLS-1$
 
+		// Use range from selection (if available) to support "surround with" style
+		// completions
+		Range range = getRangeFromSelection(document, viewer).orElseGet(() -> {
+			// no selection available: get range from prefix
+			try {
+				int line = document.getLineOfOffset(offset);
+				int lineOffset = offset - document.getLineOffset(line);
+				Position start = new Position(line, lineOffset - prefix.length());
+				Position end = new Position(line, lineOffset);
+				return new Range(start, end);
+			} catch (BadLocationException e) {
+				return null;
+			}
+		});
+		if (range == null) {
+			return new ICompletionProposal[] {};
+		}
+
 		Collection<LSPDocumentInfo> infos = LanguageServiceAccessor.getLSPDocumentInfosFor(document,
 				capabilities -> Boolean.TRUE.equals(capabilities.getReferencesProvider()));
+		LSPDocumentInfo docInfo = infos.iterator().next();
 
-		List<ICompletionProposal> proposals = new ArrayList<>();
-		for (Snippet snippet : snippets) {
-			if (snippet.matchesPrefix(prefix)) {
-				proposals.add(snippet.convertToCompletionProposal(offset, infos.iterator().next(), prefix, indent));
-			}
+		ICompletionProposal[] proposals = snippets.stream().filter(s -> s.matchesPrefix(prefix))
+				.map(s -> s.convertToCompletionProposal(offset, docInfo, prefix, indent, range))
+				.toArray(ICompletionProposal[]::new);
+		return proposals;
+	}
+
+	/**
+	 * Get the current selection from the given {@code viewer}. If there is a (non
+	 * empty) selection returns a {@code Range} computed from the selection and
+	 * returns this wrapped in an optional, otherwise returns an empty optional.
+	 *
+	 * @param document currently active document
+	 * @param viewer   the text viewer for the completion
+	 * @return either an optional containing the text selection, or an empty
+	 *         optional, if there is no (non-empty) selection.
+	 */
+	private static Optional<Range> getRangeFromSelection(IDocument document, ITextViewer viewer) {
+		if (!(viewer instanceof ITextViewerExtension9)) {
+			return Optional.empty();
 		}
-		return proposals.toArray(new ICompletionProposal[proposals.size()]);
+		ITextViewerExtension9 textViewer = (ITextViewerExtension9) viewer;
+
+		ITextSelection textSelection = textViewer.getLastKnownSelection();
+		if (textSelection == null) {
+			return Optional.empty();
+		}
+		int selectionLength = textSelection.getLength();
+		if (selectionLength <= 0) {
+			return Optional.empty();
+		}
+
+		try {
+			int startOffset = textSelection.getOffset();
+			Position startPosition = LSPEclipseUtils.toPosition(startOffset, document);
+			int endOffset = startOffset + selectionLength;
+			Position endPosition = LSPEclipseUtils.toPosition(endOffset, document);
+
+			return Optional.of(new Range(startPosition, endPosition));
+		} catch (BadLocationException e) {
+			return Optional.empty();
+		}
 	}
 
 	private static boolean isOffsetInComment(String textToOffset) {


### PR DESCRIPTION
Adjusted SnippetContentAssistProcessor to create Range from editor text
selection (if present and non-empty) for TextEdit, so templates with
$TM_SELECTED_TEXT are able to sourround the selection.

Signed-off-by: Max Bureck <max.bureck@fokus.fraunhofer.de>