### PR TITLE
Issue #299 Defaulting to empty RLS config file path

### DIFF
--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/CorrosionPreferenceInitializer.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/CorrosionPreferenceInitializer.java
@@ -58,7 +58,7 @@ public class CorrosionPreferenceInitializer extends AbstractPreferenceInitialize
 		setToolchainBestGuesses();
 
 		STORE.setDefault(RLS_PATH_PREFERENCE, getRLSPathBestGuess());
-		STORE.setDefault(RLS_CONFIGURATION_PATH_PREFERENCE, getRLSConfigurationPathBestGuess());
+		STORE.setDefault(RLS_CONFIGURATION_PATH_PREFERENCE, ""); //$NON-NLS-1$
 
 		STORE.setDefault(SYSROOT_PATH_PREFERENCE, getSysrootPathBestGuess());
 
@@ -128,10 +128,6 @@ public class CorrosionPreferenceInitializer extends AbstractPreferenceInitialize
 			}
 		}
 		return command;
-	}
-
-	private static String getRLSConfigurationPathBestGuess() {
-		return CARGO_DEFAULT_ROOT + "rls.conf"; //$NON-NLS-1$
 	}
 
 	private static String getSysrootPathBestGuess() {

--- a/org.eclipse.corrosion/src/org/eclipse/corrosion/edit/RLSStreamConnectionProvider.java
+++ b/org.eclipse.corrosion/src/org/eclipse/corrosion/edit/RLSStreamConnectionProvider.java
@@ -103,18 +103,22 @@ public class RLSStreamConnectionProvider implements StreamConnectionProvider {
 	@Override
 	public Object getInitializationOptions(URI rootUri) {
 		final String settingsPath = RustManager.getRlsConfigurationPath();
-		final File settingsFile = new File(settingsPath);
-		final Gson gson = new Gson();
-		try (JsonReader reader = new JsonReader(new FileReader(settingsFile))) {
-			return gson.fromJson(reader, HashMap.class);
-		} catch (FileNotFoundException e) {
-			CorrosionPlugin.getDefault().getLog().log(new Status(IStatus.INFO,
-					CorrosionPlugin.getDefault().getBundle().getSymbolicName(),
-					MessageFormat.format(Messages.RLSStreamConnectionProvider_rlsConfigurationNotFound, settingsPath)));
-		} catch (Throwable e) {
-			CorrosionPlugin.getDefault().getLog().log(new Status(IStatus.ERROR,
-					CorrosionPlugin.getDefault().getBundle().getSymbolicName(),
-					MessageFormat.format(Messages.RLSStreamConnectionProvider_rlsConfigurationError, settingsPath, e)));
+		if (settingsPath != null && !settingsPath.isEmpty()) {
+			final File settingsFile = new File(settingsPath);
+			final Gson gson = new Gson();
+			try (JsonReader reader = new JsonReader(new FileReader(settingsFile))) {
+				return gson.fromJson(reader, HashMap.class);
+			} catch (FileNotFoundException e) {
+				CorrosionPlugin.getDefault().getLog()
+						.log(new Status(IStatus.INFO, CorrosionPlugin.getDefault().getBundle().getSymbolicName(),
+								MessageFormat.format(Messages.RLSStreamConnectionProvider_rlsConfigurationNotFound,
+										settingsPath)));
+			} catch (Throwable e) {
+				CorrosionPlugin.getDefault().getLog()
+						.log(new Status(IStatus.ERROR, CorrosionPlugin.getDefault().getBundle().getSymbolicName(),
+								MessageFormat.format(Messages.RLSStreamConnectionProvider_rlsConfigurationError,
+										settingsPath, e)));
+			}
 		}
 		return getDefaultInitializationOptions();
 	}


### PR DESCRIPTION
Now in the preferences, the location to an rls.conf file will be empty.
An empty string will now skip configuration loading and create a
default initialization configuration.

This will prevent log messages about a missing config file by default,
since the RLS does not ship with an rls.config anymore. Unfortunately,
the RLS does not document at all how an
InitializeParams#initializationOptions message looks like, so we cannot
reference from the Corrosion document to an RLS page explaining the
content of an rls.conf file.