### PR TITLE
#301 Switch Oomph setup git URI to HTTPS

### DIFF
--- a/target-platform/Corrosion.setup
+++ b/target-platform/Corrosion.setup
@@ -72,22 +72,7 @@
   <setupTask
       xsi:type="git:GitCloneTask"
       id="git.clone.corrosion.git"
-      remoteURI="eclipse/corrosion">
-    <annotation
-        source="http://www.eclipse.org/oomph/setup/InducedChoices">
-      <detail
-          key="inherit">
-        <value>github.remoteURIs</value>
-      </detail>
-      <detail
-          key="label">
-        <value>${scope.project.label} Github repository</value>
-      </detail>
-      <detail
-          key="target">
-        <value>remoteURI</value>
-      </detail>
-    </annotation>
+      remoteURI="https://github.com/eclipse/corrosion.git">
     <description>Corrosion</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
This change is done to allow git clone without SSH or GitHub account.
New users can get up and running faster this way.