### PR TITLE
Issue #301 Preparation for inclusion in central Eclipse Projects index

### DIFF
--- a/target-platform/Corrosion.setup
+++ b/target-platform/Corrosion.setup
@@ -115,7 +115,7 @@
   </stream>
   <logicalProjectContainer
       xsi:type="setup:ProjectCatalog"
-      href="index:/org.eclipse.setup#//@projectCatalogs[name='com.github']"/>
+      href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']"/>
   <description>
     Corrosion is a Rust development plugin for the Eclipse IDE, 
     providing a rich edition experience through integration with 


### PR DESCRIPTION
Changing the logical parent to Eclipse projects for preparation for
inclusion into the central Oomph project catalogue.