### PR TITLE
Issue #301 Preparation for eclipse+installer link.

### DIFF
--- a/target-platform/CorrosionConfiguration.setup
+++ b/target-platform/CorrosionConfiguration.setup
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="Corrosion">
+  <installation
+      name="corrosion.installation"
+      label="Corrosion Installation">
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.products']/@products[name='epp.package.committers']/@versions[name='latest.released']"/>
+    <description>The Corrosion Development IDE</description>
+  </installation>
+  <workspace
+      name="corrosion.workspace"
+      label="Corrosion Workspace">
+    <description>Workspace for working on the Corrosion projects.</description>
+    <setupTask
+        xsi:type="setup:VariableTask"
+        name="eclipse.target.platform"
+        value="${eclipse.target.platform.latest}"/>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='corrosion']/@streams[name='master']"/>
+  </workspace>
+  <description>
+    Corrosion is a Rust development plugin for the Eclipse IDE, 
+    providing a rich edition experience through integration with 
+    the Rust Language Server and Cargo.
+  </description>
+</setup:Configuration>


### PR DESCRIPTION
The eclipse installer allows registering the protocol eclipse+installer
to handle installations via web links. The link must point to an Oomph
model containing an Oomph Configuration element. This configuration
information which eclipse product and which project is selected in the
Eclipse installer.
The same link can also be dropped onto the installer, if registering
the protocol is not wanted.

This commit prepares such a Configuration model.