### PR TITLE
Issue #301 Update of documentation for setting up an IDE for Corrosion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,19 +5,25 @@ Issue reports and feature requests are always appreciated and are made in the [I
 
 ## Code for Corrosion
 
-### Building locally
+### Automatic Setup
 
-Local build happens with a simple `mvnw clean verify`. Main build output is a p2 repository that you can find in `repository/target/repository`. You can use it to install and test the built artifacts in a working Eclipse IDE. 
+The easiest way to get an IDE to work on Corrosion is to use the Oomph setup.
+If you use the Eclipse installer, have a look at this [installation page](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse/corrosion/master/target-platform/CorrosionConfiguration.setup).
+It will guide the installation and complete setup of a development environment for Corrosion.
 
-Note that on windows the command cannot be invoked from PowerShell, but only from CMD.
+If you already have an Eclipse installation, use the main menu entry `File > Import ...` and in the import wizard, select `Oomph > Projects from Catalog`.
+On the next wizard page select entry `Eclipse Projects > Corrosion` and follow the wizard until the IDE is set up for development on Corrosion.
 
-### Modify Corrosion in the Eclipse IDE
+### Manual Setup
+
+This option is for everyone who wants to set up an Eclipse instance manually, as an alternative to the automatic setup described above.
+
+First, clone this repository to a local location of your choice.
 
 For running Corrosion in a child Eclipse instance:
 
- - Run a first preliminary local build (see above)
  - Use [Eclipse for Eclipse Contributors](https://www.eclipse.org/downloads/packages/) or any version of the Eclipse IDE with the `Eclipse Plug-in Development Environment` plugins installed..
- - Open the following projects in the Eclipse IDE:
+ - Import the following projects into the Eclipse IDE:
    - `org.eclipse.corrosion`
    - `target-platform`
    - `org.eclipse.corrosion.tests`
@@ -27,6 +33,17 @@ For running Corrosion in a child Eclipse instance:
    - Press the `Refresh` button and wait for completion
    - In the top right corner, press the `Set as Active Target Platform` button
  - Run the `org.eclipse.corrosion` project as an `Eclipse Application` (Right-click on project > `Run As` > `Eclipse Application`; or using the Launch Configuration dialog)
+
+### Building locally
+
+Local build happens with a simple `mvnw clean verify`. Main build output is a p2 repository that you can find in `repository/target/repository`. You can use it to install and test the built artifacts in a working Eclipse IDE.  
+Depending on your OS, you may have to prefix the command with `./` . 
+
+Note that on Windows the command cannot be invoked from PowerShell, but only from CMD.
+
+The repository also contains "External Tools" launch configurations (for *nix and Windows systems) to start the command from within the IDE.
+In Eclipse open the main menu entry `Run > External Tools > External Tools Configurations ...` to select and start the 
+configuration matching your operating system.
 
 ## Making Pull Requests
 


### PR DESCRIPTION
The CONTRIBUTING.md file is now updated to point out how to install
an IDE for working on Corrosion. This now includes the Oomph based
installation and setup of an Eclipse Instance via the installer or
project import via Oomph.