### PR TITLE
Build against 2020-12 Eclipse release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<maven>3.6.3</maven>
 	</prerequisites>
 	<properties>
-		<tycho-version>2.1.0</tycho-version>
+		<tycho-version>2.2.0-SNAPSHOT</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/corrosion.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>

--- a/target-platform/target-platform.target
+++ b/target-platform/target-platform.target
@@ -3,7 +3,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.ui.tests.harness" version="0.0.0"/>
 <unit id="org.eclipse.unittest.ui" version="0.0.0"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.18milestones/S-4.18RC2-202012021800/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.18/R-4.18-202012021800/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.lsp4e" version="0.0.0"/>
@@ -28,7 +28,7 @@
 <unit id="org.apache.commons.io" version="0.0.0"/>
 <unit id="com.google.gson" version="0.0.0"/>
 <unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
-<repository location="https://download.eclipse.org/releases/2020-09/"/>
+<repository location="https://download.eclipse.org/releases/2020-12/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>


### PR DESCRIPTION
The 4.18milestones repo is gone so without this one build is broken.
Needs bump to Tycho 2.2.0-SNAPSHOT for the JUnit 5.7 support.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>