### PR TITLE
Remove pack200 stuff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<includePackedArtifacts>true</includePackedArtifacts>
 					<target>
 						<artifact>
 							<groupId>${project.groupId}</groupId>
@@ -185,20 +184,6 @@
 			<build>
 				<plugins>
 					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200a-plugin</artifactId>
-						<version>${tycho-version}</version>
-						<executions>
-							<execution>
-								<id>pack200-normalize</id>
-								<phase>package</phase>
-								<goals>
-									<goal>normalize</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
 						<version>1.1.7</version>
@@ -208,20 +193,6 @@
 								<phase>package</phase>
 								<goals>
 									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.eclipse.tycho.extras</groupId>
-						<artifactId>tycho-pack200b-plugin</artifactId>
-						<version>${tycho-version}</version>
-						<executions>
-							<execution>
-								<id>pack200-pack</id>
-								<phase>package</phase>
-								<goals>
-									<goal>pack</goal>
 								</goals>
 							</execution>
 						</executions>


### PR DESCRIPTION
Corrosion is mainly shipped by the IDE, which does include Java 14 and
thus is not compatible with pack200.
Let's simplify things and get rid of pack200, assuming the majority of
users are using Java 14+

Signed-off-by: Mickael Istria <mistria@redhat.com>