### PR TITLE
Issue #383 - Un-associate LS with Cargo.toml by default

### DIFF
--- a/org.eclipse.corrosion/plugin.xml
+++ b/org.eclipse.corrosion/plugin.xml
@@ -49,10 +49,6 @@
             contentType="org.eclipse.corrosion.rust"
             id="org.eclipse.corrosion.rls">
       </contentTypeMapping>
-      <contentTypeMapping
-            contentType="org.eclipse.corrosion.manifest"
-            id="org.eclipse.corrosion.rls">
-      </contentTypeMapping>
    </extension>
    <extension
          point="org.eclipse.tm4e.registry.grammars">


### PR DESCRIPTION
Since move to rust-analyzer, the state of .toml files shouldn't be sent
to the Language Server, or rust-analyzer will try to parse them as Rust
file and report loads of unrelated errors.